### PR TITLE
Github Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,4 +67,5 @@ jobs:
           asset_path: ./release.tar.gz
           asset_name: release.tar.gz
           asset_content_type: application/gzip
-    
+ 
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Create TAR.GZ package
         run: |
-          cd build
           tar -czf ../${{ env.ArchiveName }}.tar.gz ./LongEssayAssessment
         shell: bash
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - '*'  # Trigger only when a tag is pushed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Install dependencies
+        run: composer install --no-dev --prefer-dist --optimize-autoloader
+
+      - name: Prepare application for packaging
+        run: |
+          mkdir -p build
+          rsync -av --exclude='vendor/' --exclude='.git/' ./ build/
+
+      - name: Create ZIP package
+        run: |
+          cd build
+          zip -r ../release.zip ./*
+        shell: bash
+
+      - name: Create TAR.GZ package
+        run: |
+          cd build
+          tar -czf ../release.tar.gz ./*
+        shell: bash
+
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release.zip
+          asset_name: release.zip
+          asset_content_type: application/zip
+
+      - name: Upload TAR.GZ Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release.tar.gz
+          asset_name: release.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    env:
+        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', github.ref ) }}
+        
     runs-on: ubuntu-latest
 
     steps:
@@ -24,18 +27,17 @@ jobs:
       - name: Prepare application for packaging
         run: |
           mkdir -p build
-          rsync -av --exclude='.github/' --exclude='.git/' ./ build/
+          rsync -av --exclude='.github/' --exclude='.git/' ./ LongEssayAssesment/
 
       - name: Create ZIP package
         run: |
-          cd build
-          zip -r ../release.zip ./*
+          zip -r ../${{ env.ArchiveName }}.zip ./LongEssayAssesment
         shell: bash
 
       - name: Create TAR.GZ package
         run: |
           cd build
-          tar -czf ../release.tar.gz ./*
+          tar -czf ../${{ env.ArchiveName }}.tar.gz ./LongEssayAssesment
         shell: bash
       
       - name: Create Release
@@ -56,8 +58,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./release.zip
-          asset_name: release.zip
+          asset_path: ./${{ env.ArchiveName }}.zip
+          asset_name: ${{ env.ArchiveName }}.zip
           asset_content_type: application/zip
 
       - name: Upload Release Asset TAR.GZ
@@ -67,8 +69,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./release.tar.gz
-          asset_name: release.tar.gz
+          asset_path: ./${{ env.ArchiveName }}.tar.gz
+          asset_name: ${{ env.ArchiveName }}.tar.gz
           asset_content_type: application/gzip
  
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Prepare application for packaging
         run: |
           mkdir -p build
-          rsync -av --exclude='vendor/' --exclude='.git/' ./ build/
+          rsync -av --exclude='.github/' --exclude='.git/' ./ build/
 
       - name: Create ZIP package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     env:
-        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', github.ref_name ) }}
+        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', ${{ github.ref_name#v }} ) }}
         
     runs-on: ubuntu-latest
 
@@ -31,12 +31,12 @@ jobs:
 
       - name: Create ZIP package
         run: |
-          zip -r ../${{ env.ArchiveName }}.zip ./LongEssayAssessment
+          zip -r ./${{ env.ArchiveName }}.zip ./LongEssayAssessment
         shell: bash
 
       - name: Create TAR.GZ package
         run: |
-          tar -czf ../${{ env.ArchiveName }}.tar.gz ./LongEssayAssessment
+          tar -czf ./${{ env.ArchiveName }}.tar.gz ./LongEssayAssessment
         shell: bash
       
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,15 @@ on:
 jobs:
   build:
     env:
-        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', ${{ github.ref_name#v }} ) }}
-        
+        ArchiveName: LongEssayAssessment_Release-
+
     runs-on: ubuntu-latest
 
     steps:
+      - name: Remove v prefix
+        id: removev
+        run: echo "::set-output name=ref_name::$(echo ${{ github.ref_name }} | perl -0777 -pe 's/^v//')"
+
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -31,12 +35,12 @@ jobs:
 
       - name: Create ZIP package
         run: |
-          zip -r ./${{ env.ArchiveName }}.zip ./LongEssayAssessment
+          zip -r ./${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.zip ./LongEssayAssessment
         shell: bash
 
       - name: Create TAR.GZ package
         run: |
-          tar -czf ./${{ env.ArchiveName }}.tar.gz ./LongEssayAssessment
+          tar -czf ./${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.tar.gz ./LongEssayAssessment
         shell: bash
       
       - name: Create Release
@@ -57,8 +61,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./${{ env.ArchiveName }}.zip
-          asset_name: ${{ env.ArchiveName }}.zip
+          asset_path: ./${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.zip
+          asset_name: ${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.zip
           asset_content_type: application/zip
 
       - name: Upload Release Asset TAR.GZ
@@ -68,8 +72,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./${{ env.ArchiveName }}.tar.gz
-          asset_name: ${{ env.ArchiveName }}.tar.gz
+          asset_path: ./${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.tar.gz
+          asset_name: ${{ env.ArchiveName }}${{ steps.removev.outputs.ref_name }}.tar.gz
           asset_content_type: application/gzip
  
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,34 @@ jobs:
           cd build
           tar -czf ../release.tar.gz ./*
         shell: bash
-
-      - name: Upload Release Assets
-        uses: actions/upload-release-asset@v1
+      
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./release.zip
           asset_name: release.zip
           asset_content_type: application/zip
 
-      - name: Upload TAR.GZ Asset
+      - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./release.tar.gz
           asset_name: release.tar.gz
           asset_content_type: application/gzip
+    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         shell: bash
       
       - name: Create Release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +50,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Asset ZIP
+        id: upload-release-asset_zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,6 +61,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Release Asset TAR.GZ
+        id: upload-release-asset_tar
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
+      - name: Upload Release Asset ZIP
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
           asset_name: release.zip
           asset_content_type: application/zip
 
-      - name: Upload Release Asset
+      - name: Upload Release Asset TAR.GZ
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     env:
-        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', github.ref ) }}
+        ArchiveName: ${{ format('LongEssayAssessment_Release-{0}', github.ref_name ) }}
         
     runs-on: ubuntu-latest
 
@@ -27,17 +27,17 @@ jobs:
       - name: Prepare application for packaging
         run: |
           mkdir -p build
-          rsync -av --exclude='.github/' --exclude='.git/' ./ LongEssayAssesment/
+          rsync -av --exclude='.github/' --exclude='.git/' ./ LongEssayAssessment/
 
       - name: Create ZIP package
         run: |
-          zip -r ../${{ env.ArchiveName }}.zip ./LongEssayAssesment
+          zip -r ../${{ env.ArchiveName }}.zip ./LongEssayAssessment
         shell: bash
 
       - name: Create TAR.GZ package
         run: |
           cd build
-          tar -czf ../${{ env.ArchiveName }}.tar.gz ./LongEssayAssesment
+          tar -czf ../${{ env.ArchiveName }}.tar.gz ./LongEssayAssessment
         shell: bash
       
       - name: Create Release


### PR DESCRIPTION
Vorgehensweise für neue Releases:
1. Die Pluginversion muss in der `plugin.php` hochgesetzt werden
2. Die `CHANGELOG.md` muss ebenfalls angepasst werden.
3. `git commit -am "Version 1.X"`
4. `git tag -a v1.X -m "Release 1.X"`
5. `git push origin release1_ilias7`
6. `git push origin tag v1.X`

Anschließend erstellt die Github-Action automatisch die Release-Seite ´Release v1.X´ und fügt die Dateien `release.zip` und `release.tar.gz` hinzu. Diese Dateien enthalten bereits das `vendor/` Verzeichniss.