### PR TITLE
Export- und Importfunktion

### DIFF
--- a/classes/Task/abstract.CriteriaGUI.php
+++ b/classes/Task/abstract.CriteriaGUI.php
@@ -80,7 +80,7 @@ abstract class CriteriaGUI extends BaseGUI
             $items[] = $this->custom_factory->item()->formItem($this->buildItemTitle($item))
                 ->withName($item->getId())
                 ->withNoLead()
-                ->withDescription(nl2br($item->getDescription()))
+                ->withDescription(nl2br($item->getDescription() ?? ''))
                 ->withActions($this->uiFactory->dropdown()->standard([
                     $this->uiFactory->button()->shy($this->lng->txt("edit"), "")->withOnClick($edit_modal->getShowSignal()),
                     $this->uiFactory->button()->shy($this->lng->txt("remove"), $this->ctrl->getLinkTarget($this, "deleteItems"))

--- a/classes/class.ilLongEssayAssessmentExporter.php
+++ b/classes/class.ilLongEssayAssessmentExporter.php
@@ -3,6 +3,7 @@
 use ILIAS\Plugin\LongEssayAssessment\LongEssayAssessmentDI;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectRepository;
 use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
+use ILIAS\Plugin\LongEssayAssessment\Data\RecordData;
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -23,7 +24,6 @@ use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
 class ilLongEssayAssessmentExporter extends ilXmlExporter
 {
     private LongEssayAssessmentDI $localDI;
-    private ilLongEssayAssessmentPlugin $plugin;
 
     private ObjectRepository $object_repo;
     private TaskRepository $task_repo;
@@ -33,10 +33,9 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
     public function __construct()
     {
         $this->localDI = LongEssayAssessmentDI::getInstance();
-        $this->plugin = ilLongEssayAssessmentPlugin::getInstance();
 
-        $object_repo = $this->localDI->getObjectRepo();
-        $task_repo = $this->localDI->getTaskRepo();
+        $this->object_repo = $this->localDI->getObjectRepo();
+        $this->task_repo = $this->localDI->getTaskRepo();
     }
 
     public function getXmlExportTailDependencies(
@@ -55,7 +54,7 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
         return $deps;
     }
 
-    public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
+    public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         if (ilObject::_lookupType((int) $a_id) !== 'xlas') {
             return '';
@@ -66,28 +65,26 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
         $this->object = new ilObjLongEssayAssessment($ref_id);
 
         $writer = new ilXmlWriter();
-        $writer->xmlStartTag("xlas");
+        $writer->xmlStartTag("LongEssayAssessment");
 
         // basic object data
-        $writer->xmlElement("title", null, $this->object->getTitle());
-        $writer->xmlElement("description", null, $this->object->getDescription());
+        $writer->xmlElement("Title", null, $this->object->getTitle());
+        $writer->xmlElement("Description", null, $this->object->getDescription());
 
-        // LOM meta data
-        $md2xml = new ilMD2XML($this->object->getId(), $this->object->getId(), 'xlas');
-        $md2xml->startExport();
-        $writer->appendXML($md2xml->getXML());
+        $this->addModelXml($writer, $this->object_repo->getObjectSettingsById($a_id));
+        $this->addModelXml($writer, $this->task_repo->getTaskSettingsById($a_id));
 
-        $writer->xmlEndTag("xlas");
+        $writer->xmlEndTag("LongEssayAssessment");
 
         return $writer->xmlDumpMem(false);
     }
 
-    public function init() : void
+    public function init(): void
     {
-        // TODO: Implement init() method.
+        // no initialisation needed at the moment
     }
 
-    public function getValidSchemaVersions(string $a_entity) : array
+    public function getValidSchemaVersions(string $a_entity): array
     {
         return array(
             "5.2.0" => array(
@@ -97,5 +94,19 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
                 "max" => ""
             )
         );
+    }
+
+    /**
+     * Add the xml of a RecordData model to the writer
+     */
+    private function addModelXml(ilXmlWriter $writer, RecordData $model): void
+    {
+        $reflect = new ReflectionClass($model);
+        $writer->xmlStartTag($reflect->getShortName());
+        foreach ($model->row() as $key => $value) {
+            $name = str_replace('_', '', ucwords($key, '_'));
+            $writer->xmlElement($name, null, (string) $value, true, true);
+        }
+        $writer->xmlEndTag($reflect->getShortName());
     }
 }

--- a/classes/class.ilLongEssayAssessmentExporter.php
+++ b/classes/class.ilLongEssayAssessmentExporter.php
@@ -73,6 +73,19 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
 
         $this->addModelXml($writer, $this->object_repo->getObjectSettingsById($a_id));
         $this->addModelXml($writer, $this->task_repo->getTaskSettingsById($a_id));
+        $this->addModelXml($writer, $this->task_repo->getEditorSettingsById($a_id));
+        $this->addModelXml($writer, $this->task_repo->getCorrectionSettingsById($a_id));
+        $this->addModelXml($writer, $this->task_repo->getPdfSettingsById($a_id));
+        foreach ($this->object_repo->getGradeLevelsByObjectId($a_id) as $model) {
+            $this->addModelXml($writer, $model);
+        }
+        foreach ($this->object_repo->getRatingCriteriaByObjectId($a_id) as $model) {
+            $this->addModelXml($writer, $model);
+        }
+        foreach ($this->task_repo->getLocationsByTaskId($a_id) as $model) {
+            $this->addModelXml($writer, $model);
+        }
+        // todo: resources
 
         $writer->xmlEndTag("LongEssayAssessment");
 

--- a/classes/class.ilLongEssayAssessmentExporter.php
+++ b/classes/class.ilLongEssayAssessmentExporter.php
@@ -109,10 +109,11 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
                     $identification = $this->resource->manage()->find($file_id);
                     $resource = $this->resource->manage()->getResource($identification);
                     $file_name = $resource->getCurrentRevision()->getTitle();
-                    $export_fs->writeStream($files_path . '/' . $file_id,
-                        $this->resource->consume()->stream($identification)->getStream());
-                }
-                catch (Exception $e) {
+                    $export_fs->writeStream(
+                        $files_path . '/' . $file_id,
+                        $this->resource->consume()->stream($identification)->getStream()
+                    );
+                } catch (Exception $e) {
                     $this->logger->error(sprintf('LongEssayAssessment: EXPORT (ref_id %s): ', $ref_id)
                         . $e->getMessage());
                     $file_id = '';
@@ -122,8 +123,8 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
 
             /** @noinspection PhpParamsInspection */
             $row = $this->getModelRowForXml($model);
-            $row['FileId'] =  $file_id;
-            $row['FileName'] =  $file_name;
+            $row['FileId'] = $file_id;
+            $row['FileName'] = $file_name;
             $this->addRowXml($writer, 'Resource', $row);
         }
 

--- a/classes/class.ilLongEssayAssessmentExporter.php
+++ b/classes/class.ilLongEssayAssessmentExporter.php
@@ -1,0 +1,101 @@
+<?php
+
+use ILIAS\Plugin\LongEssayAssessment\LongEssayAssessmentDI;
+use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectRepository;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+class ilLongEssayAssessmentExporter extends ilXmlExporter
+{
+    private LongEssayAssessmentDI $localDI;
+    private ilLongEssayAssessmentPlugin $plugin;
+
+    private ObjectRepository $object_repo;
+    private TaskRepository $task_repo;
+
+    private ilObjLongEssayAssessment $object;
+
+    public function __construct()
+    {
+        $this->localDI = LongEssayAssessmentDI::getInstance();
+        $this->plugin = ilLongEssayAssessmentPlugin::getInstance();
+
+        $object_repo = $this->localDI->getObjectRepo();
+        $task_repo = $this->localDI->getTaskRepo();
+    }
+
+    public function getXmlExportTailDependencies(
+        string $a_entity,
+        string $a_target_release,
+        array $a_ids
+    ): array {
+        $deps = [];
+        // service settings
+        $deps[] = [
+            "component" => "Services/Object",
+            "entity" => "common",
+            "ids" => $a_ids
+        ];
+
+        return $deps;
+    }
+
+    public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
+    {
+        if (ilObject::_lookupType((int) $a_id) !== 'xlas') {
+            return '';
+        }
+
+        $ref_ids = ilObject::_getAllReferences($a_id);
+        $ref_id = array_shift($ref_ids);
+        $this->object = new ilObjLongEssayAssessment($ref_id);
+
+        $writer = new ilXmlWriter();
+        $writer->xmlStartTag("xlas");
+
+        // basic object data
+        $writer->xmlElement("title", null, $this->object->getTitle());
+        $writer->xmlElement("description", null, $this->object->getDescription());
+
+        // LOM meta data
+        $md2xml = new ilMD2XML($this->object->getId(), $this->object->getId(), 'xlas');
+        $md2xml->startExport();
+        $writer->appendXML($md2xml->getXML());
+
+        $writer->xmlEndTag("xlas");
+
+        return $writer->xmlDumpMem(false);
+    }
+
+    public function init() : void
+    {
+        // TODO: Implement init() method.
+    }
+
+    public function getValidSchemaVersions(string $a_entity) : array
+    {
+        return array(
+            "5.2.0" => array(
+                "namespace" => "http://www.ilias.de/Plugins/LongEssayAssessment/md/5_2",
+                "xsd_file" => "ilias_md_5_2.xsd",
+                "min" => "5.2.0",
+                "max" => ""
+            )
+        );
+    }
+}

--- a/classes/class.ilLongEssayAssessmentExporter.php
+++ b/classes/class.ilLongEssayAssessmentExporter.php
@@ -4,6 +4,10 @@ use ILIAS\Plugin\LongEssayAssessment\LongEssayAssessmentDI;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectRepository;
 use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
 use ILIAS\Plugin\LongEssayAssessment\Data\RecordData;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\Resource;
+use ILIAS\Filesystem\Util\LegacyPathHelper;
+use ILIAS\DI\LoggingServices;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -23,7 +27,8 @@ use ILIAS\Plugin\LongEssayAssessment\Data\RecordData;
 
 class ilLongEssayAssessmentExporter extends ilXmlExporter
 {
-    private LongEssayAssessmentDI $localDI;
+    private ResourceStorage $resource;
+    private ilComponentLogger $logger;
 
     private ObjectRepository $object_repo;
     private TaskRepository $task_repo;
@@ -32,10 +37,14 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
 
     public function __construct()
     {
-        $this->localDI = LongEssayAssessmentDI::getInstance();
+        global $DIC;
+        $this->resource = $DIC->resourceStorage();
+        $this->logger = $DIC->logger()->xlas();
 
-        $this->object_repo = $this->localDI->getObjectRepo();
-        $this->task_repo = $this->localDI->getTaskRepo();
+        $local_di = LongEssayAssessmentDI::getInstance();
+
+        $this->object_repo = $local_di->getObjectRepo();
+        $this->task_repo = $local_di->getTaskRepo();
     }
 
     public function getXmlExportTailDependencies(
@@ -59,6 +68,11 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
         if (ilObject::_lookupType((int) $a_id) !== 'xlas') {
             return '';
         }
+
+        $export_fs = LegacyPathHelper::deriveFilesystemFrom($this->getAbsoluteExportDirectory());
+        $export_path = LegacyPathHelper::createRelativePath($this->getAbsoluteExportDirectory());
+        $files_path = $export_path . '/Files';
+        $export_fs->createDir($files_path);
 
         $ref_ids = ilObject::_getAllReferences($a_id);
         $ref_id = array_shift($ref_ids);
@@ -85,7 +99,34 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
         foreach ($this->task_repo->getLocationsByTaskId($a_id) as $model) {
             $this->addModelXml($writer, $model);
         }
-        // todo: resources
+        foreach ($this->task_repo->getResourceByTaskId($a_id) as $model) {
+
+            /** @var Resource $model */
+            $file_id = $model->getFileId();
+            $file_name = '';
+            if (!empty($file_id)) {
+                try {
+                    $identification = $this->resource->manage()->find($file_id);
+                    $resource = $this->resource->manage()->getResource($identification);
+                    $file_name = $resource->getCurrentRevision()->getTitle();
+                    $export_fs->writeStream($files_path . '/' . $file_id,
+                        $this->resource->consume()->stream($identification)->getStream());
+                }
+                catch (Exception $e) {
+                    $this->logger->error(sprintf('LongEssayAssessment: EXPORT (ref_id %s): ', $ref_id)
+                        . $e->getMessage());
+                    $file_id = '';
+                    $file_name = '';
+                }
+            }
+
+            /** @noinspection PhpParamsInspection */
+            $row = $this->getModelRowForXml($model);
+            $row['FileId'] =  $file_id;
+            $row['FileName'] =  $file_name;
+            $this->addRowXml($writer, 'Resource', $row);
+        }
+
 
         $writer->xmlEndTag("LongEssayAssessment");
 
@@ -115,11 +156,31 @@ class ilLongEssayAssessmentExporter extends ilXmlExporter
     private function addModelXml(ilXmlWriter $writer, RecordData $model): void
     {
         $reflect = new ReflectionClass($model);
-        $writer->xmlStartTag($reflect->getShortName());
-        foreach ($model->row() as $key => $value) {
-            $name = str_replace('_', '', ucwords($key, '_'));
+        $this->addRowXml($writer, $reflect->getShortName(), $this->getModelRowForXml($model));
+    }
+
+    /**
+     * Add the xml of a row to the writer
+     */
+    private function addRowXml(ilXmlWriter $writer, string $tag, array $row): void
+    {
+        $writer->xmlStartTag($tag);
+        foreach ($row as $name => $value) {
             $writer->xmlElement($name, null, (string) $value, true, true);
         }
-        $writer->xmlEndTag($reflect->getShortName());
+        $writer->xmlEndTag($tag);
+    }
+
+    /**
+     * Get a model row with keys renamed for Xml
+     */
+    private function getModelRowForXml(RecordData $model): array
+    {
+        $row = [];
+        foreach ($model->row() as $key => $value) {
+            $name = str_replace('_', '', ucwords($key, '_'));
+            $row[$name] = $value;
+        }
+        return $row;
     }
 }

--- a/classes/class.ilLongEssayAssessmentImporter.php
+++ b/classes/class.ilLongEssayAssessmentImporter.php
@@ -13,6 +13,15 @@ use ILIAS\Plugin\LongEssayAssessment\Data\Task\PdfSettings;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\GradeLevel;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\RatingCriterion;
 use ILIAS\Plugin\LongEssayAssessment\Data\Task\Location;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\Resource;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+use ILIAS\Filesystem\Util\LegacyPathHelper;
+use ILIAS\Plugin\LongEssayAssessment\Task\ResourceResourceStakeholder;
+use ILIAS\ResourceStorage\Information\FileInformation;
+use ILIAS\ResourceStorage\Resource\ResourceBuilder;
+use ILIAS\Filesystem\Filesystem;
+use ILIAS\ResourceStorage\Resource\InfoResolver\StreamInfoResolver;
+use ILIAS\ResourceStorage\Resource\ResourceType;
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -32,23 +41,51 @@ use ILIAS\Plugin\LongEssayAssessment\Data\Task\Location;
 
 class ilLongEssayAssessmentImporter extends ilXmlImporter
 {
+    private ResourceBuilder $resource_builder;
+    private ResourceResourceStakeholder $resource_stakeholder;
+    private ilComponentLogger $logger;
+
     private LongEssayAssessmentDI $localDI;
     private ilLongEssayAssessmentPlugin $plugin;
 
     private ObjectRepository $object_repo;
     private TaskRepository $task_repo;
     private DataService $data_service;
-
     private ilObjLongEssayAssessment $object;
 
+    private Filesystem $import_fs;
+    private string $files_path;
 
     public function __construct()
     {
+        global $DIC;
+
+        $this->resource_builder = new ResourceBuilder(
+            $DIC[InitResourceStorage::D_STORAGE_HANDLERS],
+            $DIC[InitResourceStorage::D_REPOSITORIES],
+            $DIC[InitResourceStorage::D_LOCK_HANDLER],
+            $DIC[InitResourceStorage::D_STREAM_ACCESS],
+            $DIC[InitResourceStorage::D_FILENAME_POLICY],
+        );
+        $this->resource_stakeholder = new ResourceResourceStakeholder($DIC->user()->getId());
+
+        $this->logger = $DIC->logger()->xlas();
+
         $this->localDI = LongEssayAssessmentDI::getInstance();
         $this->plugin = ilLongEssayAssessmentPlugin::getInstance();
 
         $this->object_repo = $this->localDI->getObjectRepo();
         $this->task_repo = $this->localDI->getTaskRepo();
+    }
+
+    /**
+     * Initialisations after import directory is set
+     */
+    public function init(): void
+    {
+        $import_path = LegacyPathHelper::createRelativePath($this->getImportDirectory());
+        $this->import_fs = LegacyPathHelper::deriveFilesystemFrom($this->getImportDirectory());
+        $this->files_path = $import_path . '/Plugins/xlas/set_1/expDir_1/Files';
     }
 
     public function importXmlRepresentation(
@@ -57,7 +94,6 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
         string $a_xml,
         ilImportMapping $a_mapping
     ): void {
-
         $this->object = new ilObjLongEssayAssessment();
         $this->object->create(true);
 
@@ -81,7 +117,8 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
                     break;
                 case 'TaskSettings':
                     $model = TaskSettings::from($row = $this->getRowFromXml($element, TaskSettings::model()));
-                    $this->object_repo->save($model->setTaskId($new_id)
+                    $this->object_repo->save(
+                        $model->setTaskId($new_id)
                         ->setDescription($data_service->cleanupRichText($row['Description'] ?? null))
                         ->setClosingMessage($data_service->cleanupRichText($row['ClosingMessage'] ?? null))
                         ->setInstructions($data_service->cleanupRichText($row['Instructions'] ?? null))
@@ -112,6 +149,19 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
                     $model = Location::from($row = $this->getRowFromXml($element, Location::model()));
                     $this->task_repo->save($model->setTaskId($new_id)->setId(0));
                     break;
+                case 'Resource':
+                    $model = Resource::from($row = $this->getRowFromXml($element, Resource::model()));
+                    $file_id = '';
+                    try {
+                        $file_id = $this->addResourceFile(
+                            ilUtil::secureString($row['FileId'] ?? ''),
+                            ilUtil::secureString($row['FileName'] ?? '')
+                        );
+                    } catch (Exception $e) {
+                        $this->logger->error(sprintf('LongEssayAssessment: IMPORT (obj_id %s): ', $new_id)
+                            . $e->getMessage());
+                    }
+                    $this->task_repo->save($model->setTaskId($new_id)->setFileId($file_id)->setId(0));
             }
         }
 
@@ -159,12 +209,42 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
                         break;
                     case 'string':
                     case '?string':
-                        $row[$property->getName()] = (string) $value;
+                        $row[$property->getName()] = ilUtil::secureString((string) $value);
                         break;
                 }
             }
         }
 
         return $row;
+    }
+
+    /**
+     * Add a file resource and return their id as string
+     * copied to set the file name
+     * @see ILIAS\ResourceStorage\Manager\BaseManager::newStreamBased
+     */
+    public function addResourceFile(string $export_file_id, string $export_file_name): string
+    {
+        $stream = $this->import_fs->readStream($this->files_path . '/' . $export_file_id);
+
+        $info_resolver = new StreamInfoResolver(
+            $stream,
+            1,
+            $this->resource_stakeholder->getOwnerOfNewResources(),
+            $export_file_name ?? $stream->getMetadata()['uri'],
+            $export_file_name
+        );
+
+        $resource = $this->resource_builder->newFromStream(
+            $stream,
+            $info_resolver,
+            true,
+            ResourceType::SINGLE_FILE
+        );
+        $resource->addStakeholder($this->resource_stakeholder);
+        $this->resource_builder->store($resource);
+
+        $stream->close();
+        return (string) $resource->getIdentification();
     }
 }

--- a/classes/class.ilLongEssayAssessmentImporter.php
+++ b/classes/class.ilLongEssayAssessmentImporter.php
@@ -3,6 +3,9 @@
 use ILIAS\Plugin\LongEssayAssessment\LongEssayAssessmentDI;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectRepository;
 use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
+use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectSettings;
+use ILIAS\Plugin\LongEssayAssessment\Data\RecordData;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskSettings;
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -36,8 +39,8 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
         $this->localDI = LongEssayAssessmentDI::getInstance();
         $this->plugin = ilLongEssayAssessmentPlugin::getInstance();
 
-        $object_repo = $this->localDI->getObjectRepo();
-        $task_repo = $this->localDI->getTaskRepo();
+        $this->object_repo = $this->localDI->getObjectRepo();
+        $this->task_repo = $this->localDI->getTaskRepo();
     }
 
     public function importXmlRepresentation(
@@ -45,20 +48,59 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
         string $a_id,
         string $a_xml,
         ilImportMapping $a_mapping
-    ) : void {
+    ): void {
 
         $this->object = new ilObjLongEssayAssessment();
         $this->object->create(true);
 
-        $xml = simplexml_load_string($a_xml);
+        $xml = new SimpleXMLElement($a_xml);
+        log_var($xml, 'xml');
 
         $object = new ilObjLongEssayAssessment();
-        $object->setTitle((string) $xml->title . " " . $this->plugin->txt('copy'));
-        $object->setDescription((string) $xml->description);
+        $object->setTitle((string) $xml->Title . " " . $this->plugin->txt('imported'));
+        $object->setDescription((string) $xml->Description);
         $object->setImportId($a_id);
         $object->create();
 
         $new_id = $object->getId();
+
+        foreach ($xml->children() as $name => $element) {
+
+            switch ($element->getName()) {
+                case "ObjectSettings":
+                    $model = $this->getModelFromXml($element, ObjectSettings::model());
+                    $model->setObjId($new_id);
+                    $this->object_repo->save($model);
+                    break;
+                case "TaskSettings":
+                    $model = $this->getModelFromXml($element, TaskSettings::model());
+                    $model->setTaskId($new_id);
+                    $this->object_repo->save($model);
+                    break;
+            }
+        }
+
         $a_mapping->addMapping("Plugins/xlas", "xlas", $a_id, $new_id);
+    }
+
+    /**
+     * Get a model from the xml representation
+     * @see ilLongEssayAssessmentExporter::addModelXml()
+     */
+    protected function getModelFromXml(SimpleXMLElement $element, RecordData $model): RecordData
+    {
+        $map = [];
+        foreach (array_keys($model->row()) as $key) {
+            $name = str_replace('_', '', ucwords($key, '_'));
+            $map[$name] = $key;
+        }
+
+        $row = [];
+        foreach ($element->children() as $name => $value) {
+            $key = $map[$name];
+            $row[$key] = (string) $value;
+        }
+
+        return $model::from($row);
     }
 }

--- a/classes/class.ilLongEssayAssessmentImporter.php
+++ b/classes/class.ilLongEssayAssessmentImporter.php
@@ -6,6 +6,13 @@ use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
 use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectSettings;
 use ILIAS\Plugin\LongEssayAssessment\Data\RecordData;
 use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskSettings;
+use ILIAS\Plugin\LongEssayAssessment\Data\DataService;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\EditorSettings;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\CorrectionSettings;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\PdfSettings;
+use ILIAS\Plugin\LongEssayAssessment\Data\Object\GradeLevel;
+use ILIAS\Plugin\LongEssayAssessment\Data\Object\RatingCriterion;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\Location;
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -30,6 +37,7 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
 
     private ObjectRepository $object_repo;
     private TaskRepository $task_repo;
+    private DataService $data_service;
 
     private ilObjLongEssayAssessment $object;
 
@@ -54,7 +62,6 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
         $this->object->create(true);
 
         $xml = new SimpleXMLElement($a_xml);
-        log_var($xml, 'xml');
 
         $object = new ilObjLongEssayAssessment();
         $object->setTitle((string) $xml->Title . " " . $this->plugin->txt('imported'));
@@ -63,44 +70,101 @@ class ilLongEssayAssessmentImporter extends ilXmlImporter
         $object->create();
 
         $new_id = $object->getId();
+        $data_service = $this->localDI->getDataService($new_id);
 
         foreach ($xml->children() as $name => $element) {
 
             switch ($element->getName()) {
-                case "ObjectSettings":
-                    $model = $this->getModelFromXml($element, ObjectSettings::model());
-                    $model->setObjId($new_id);
-                    $this->object_repo->save($model);
+                case 'ObjectSettings':
+                    $model = ObjectSettings::from($row = $this->getRowFromXml($element, ObjectSettings::model()));
+                    $this->object_repo->save($model->setObjId($new_id));
                     break;
-                case "TaskSettings":
-                    $model = $this->getModelFromXml($element, TaskSettings::model());
-                    $model->setTaskId($new_id);
-                    $this->object_repo->save($model);
+                case 'TaskSettings':
+                    $model = TaskSettings::from($row = $this->getRowFromXml($element, TaskSettings::model()));
+                    $this->object_repo->save($model->setTaskId($new_id)
+                        ->setDescription($data_service->cleanupRichText($row['Description'] ?? null))
+                        ->setClosingMessage($data_service->cleanupRichText($row['ClosingMessage'] ?? null))
+                        ->setInstructions($data_service->cleanupRichText($row['Instructions'] ?? null))
+                        ->setSolution($data_service->cleanupRichText($row['Solution'] ?? null))
+                    );
+                    break;
+                case 'EditorSettings':
+                    $model = EditorSettings::from($row = $this->getRowFromXml($element, EditorSettings::model()));
+                    $this->task_repo->save($model->setTaskId($new_id));
+                    break;
+                case 'CorrectionSettings':
+                    $model = CorrectionSettings::from($row = $this->getRowFromXml($element, CorrectionSettings::model()));
+                    $this->task_repo->save($model->setTaskId($new_id));
+                    break;
+                case 'PdfSettings':
+                    $model = PdfSettings::from($row = $this->getRowFromXml($element, PdfSettings::model()));
+                    $this->task_repo->save($model->setTaskId($new_id));
+                    break;
+                case 'GradeLevel':
+                    $model = GradeLevel::from($row = $this->getRowFromXml($element, GradeLevel::model()));
+                    $this->object_repo->save($model->setObjectId($new_id)->setId(0));
+                    break;
+                case 'RatingCriterion':
+                    $model = RatingCriterion::from($row = $this->getRowFromXml($element, RatingCriterion::model()));
+                    $this->object_repo->save($model->setObjectId($new_id)->setId(0));
+                    break;
+                case 'Location':
+                    $model = Location::from($row = $this->getRowFromXml($element, Location::model()));
+                    $this->task_repo->save($model->setTaskId($new_id)->setId(0));
                     break;
             }
         }
 
-        $a_mapping->addMapping("Plugins/xlas", "xlas", $a_id, $new_id);
+        $a_mapping->addMapping('Plugins/xlas', 'xlas', $a_id, $new_id);
     }
 
     /**
-     * Get a model from the xml representation
+     * Get a row array from the xml representation
+     * All raw data is added with the original XML element name (PascalCase) to the row
+     * Elements mapping to model properties (snake_case) and added with property names and mapped types
+     *
      * @see ilLongEssayAssessmentExporter::addModelXml()
      */
-    protected function getModelFromXml(SimpleXMLElement $element, RecordData $model): RecordData
+    protected function getRowFromXml(SimpleXMLElement $element, Object $model): array
     {
-        $map = [];
-        foreach (array_keys($model->row()) as $key) {
-            $name = str_replace('_', '', ucwords($key, '_'));
-            $map[$name] = $key;
-        }
-
         $row = [];
+
+        // raw data with PascalCase names, probably needed for additional conversions
         foreach ($element->children() as $name => $value) {
-            $key = $map[$name];
-            $row[$key] = (string) $value;
+            $value = (string) $value;
+            $row[$name] = empty($value) ? null : $value;
         }
 
-        return $model::from($row);
+        // map to object properties with snake_case, do type conversions
+        $reflect = new ReflectionClass($model);
+        foreach ($reflect->getProperties() as $property) {
+            $name = str_replace('_', '', ucwords($property->getName(), '_'));
+            $value = $row[$name] ?? null;
+
+            if ($value === null && $property->getType()->allowsNull()) {
+                $row[$property->getName()] = null;
+            } else {
+                switch ((string) $property->getType()) {
+                    case 'int':
+                    case '?int':
+                        $row[$property->getName()] = (int) $value;
+                        break;
+                    case 'float':
+                    case '?float':
+                        $row[$property->getName()] = (float) $value;
+                        break;
+                    case 'bool':
+                    case '?bool':
+                        $row[$property->getName()] = (bool) $value;
+                        break;
+                    case 'string':
+                    case '?string':
+                        $row[$property->getName()] = (string) $value;
+                        break;
+                }
+            }
+        }
+
+        return $row;
     }
 }

--- a/classes/class.ilLongEssayAssessmentImporter.php
+++ b/classes/class.ilLongEssayAssessmentImporter.php
@@ -1,0 +1,64 @@
+<?php
+
+use ILIAS\Plugin\LongEssayAssessment\LongEssayAssessmentDI;
+use ILIAS\Plugin\LongEssayAssessment\Data\Object\ObjectRepository;
+use ILIAS\Plugin\LongEssayAssessment\Data\Task\TaskRepository;
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+class ilLongEssayAssessmentImporter extends ilXmlImporter
+{
+    private LongEssayAssessmentDI $localDI;
+    private ilLongEssayAssessmentPlugin $plugin;
+
+    private ObjectRepository $object_repo;
+    private TaskRepository $task_repo;
+
+    private ilObjLongEssayAssessment $object;
+
+
+    public function __construct()
+    {
+        $this->localDI = LongEssayAssessmentDI::getInstance();
+        $this->plugin = ilLongEssayAssessmentPlugin::getInstance();
+
+        $object_repo = $this->localDI->getObjectRepo();
+        $task_repo = $this->localDI->getTaskRepo();
+    }
+
+    public function importXmlRepresentation(
+        string $a_entity,
+        string $a_id,
+        string $a_xml,
+        ilImportMapping $a_mapping
+    ) : void {
+
+        $this->object = new ilObjLongEssayAssessment();
+        $this->object->create(true);
+
+        $xml = simplexml_load_string($a_xml);
+
+        $object = new ilObjLongEssayAssessment();
+        $object->setTitle((string) $xml->title . " " . $this->plugin->txt('copy'));
+        $object->setDescription((string) $xml->description);
+        $object->setImportId($a_id);
+        $object->create();
+
+        $new_id = $object->getId();
+        $a_mapping->addMapping("Plugins/xlas", "xlas", $a_id, $new_id);
+    }
+}

--- a/classes/class.ilObjLongEssayAssessment.php
+++ b/classes/class.ilObjLongEssayAssessment.php
@@ -366,6 +366,14 @@ class ilObjLongEssayAssessment extends ilObjectPlugin
     }
 
     /**
+     * Check if the object can be exported
+     */
+    public function canExportObject(): bool
+    {
+        return $this->canEditOrgaSettings() && $this->canEditContentSettings() && $this->canEditTechnicalSettings();
+    }
+
+    /**
      * Check if the user can write the essay
      */
     public function canWrite() : bool

--- a/classes/class.ilObjLongEssayAssessmentGUI.php
+++ b/classes/class.ilObjLongEssayAssessmentGUI.php
@@ -543,7 +543,10 @@ class ilObjLongEssayAssessmentGUI extends ilObjectPluginGUI
             $this->subtabs['tab_corrector_admin'] = $tabs;
         }
 
-
+        // standard export tab
+        if ($this->object->canExportObject()) {
+            $this->addExportTab();
+        }
 
         // standard info screen tab
         if ($this->object->canViewInfoScreen()) {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -37,6 +37,7 @@ content#:#Inhalt
 copy#:#Kopieren
 edit#:#Bearbeiten
 export#:#Export
+imported#:#(importiert)
 configuration#:#Konfiguration
 update_languages#:#Sprachen aktualisieren
 reload_control_structure#:#Kontrollstruktur aktualisieren

--- a/plugin.php
+++ b/plugin.php
@@ -16,5 +16,5 @@ $responsible = 'Fred Neumann';
 $responsible_mail = 'fred.neumann@ilias.de';
 
 // features
-$supports_export = false;
+$supports_export = true;
 $learning_progress = false;


### PR DESCRIPTION
Das ILIAS-Plugin LongEssayAssessment wird um eine Export- und Import-Funktion für das ILIAS-Objekt der Langtext-Aufgabe erweitert. Der Export umfasst wie bei anderen ILIAS-Objekten alle Einstellungen, sowie die Dateien zur Aufgabenstellung, zu Lösungshinweisen und von Materialien. Er umfasst nicht die Listen von Teilnehmern und Korrekturen und auch keine Abgaben oder Korrekturen.